### PR TITLE
Added module entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
 	"exports": {
 		".": {
 			"import": "./dist/index.js"
+		},
+		"./dist/global": {
+			"import": "./dist/global.js"
 		}
 	},
 	"types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,12 @@
 	"homepage": "https://github.com/utily",
 	"private": false,
 	"type": "module",
+	"module": "./dist/index.js",
+	"exports": {
+		".": {
+			"import": "./dist/index.js"
+		}
+	},
 	"types": "dist/index.d.ts",
 	"git": {
 		"tagName": "v${version}"


### PR DESCRIPTION
* Added `module` and `exports` field to `package.json`
  * `"."` for the regular export.
  * `"./dist/global"` for `import "typedly/dist/global"` to get the global types

Both `module` field and `exports` required due to [rollup seemingly not supporting](https://github.com/rollup/plugins/issues/208) `exports` without [plugin](https://www.npmjs.com/package/@rollup/plugin-node-resolve) and we use rollup for stencil in smoothly (the plugins major version 13 seams to be the one working for stencils 4.17.x rollup version). 