### PR TITLE
faking cjs entry point for jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
 	"module": "./dist/index.js",
 	"exports": {
 		".": {
-			"import": "./dist/index.js"
+			"import": "./dist/index.js",
+			"require": "./dist/index.js"
 		},
 		"./dist/global": {
-			"import": "./dist/global.js"
+			"import": "./dist/global.js",
+			"require": "./dist/index.js"
 		}
 	},
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
This configuration pretends that a `cjs` entry point exists even though it does not. Without this `jest` / `node` fails to find the module when importing it from a test in another project. This is fine for us since we use `ts-jest` to fix the faking (I think). 

The package was installed using `npm link` to verify that it could be imported correctly.