### PR TITLE
resolvable promises

### DIFF
--- a/Promise.spec.ts
+++ b/Promise.spec.ts
@@ -109,24 +109,19 @@ describe("Promise", () => {
 	})
 	it("awaitLatest", async () => {
 		let result: number
-		console.log("1")
 		const processed = typedly.Promise.awaitLatest(work)
-		console.log("2", processed)
 		result = (await Promise.all([processed(2), processed(3), processed(5)])).reduce(
 			(result, number) => result + number,
 			0
 		)
-		console.log("3")
 		// older versions of calls to `processed()` will only resolved if it finishes before another call to `processed()` starts.
 		// if more calls occurs before it finishes it will await result from the latest call.
 		// expecting 3 * value of last call
 		expect(result).toEqual(15)
-		console.log("4")
 		result = (await Promise.all([processed(5), processed(3), processed(2)])).reduce(
 			(result, number) => result + number,
 			0
 		)
-		console.log("5")
 		expect(result).toEqual(6)
 	})
 	it("awaitLatest + lazy", async () => {

--- a/Promise.spec.ts
+++ b/Promise.spec.ts
@@ -56,7 +56,7 @@ describe("Promise", () => {
 		}
 		expect(order).toEqual(4)
 	})
-	it(`typedly.Promise used with lazy function`, async () => {
+	it(`typedly.Promise lazy + awaitLatest compatibility`, async () => {
 		const lazy = typedly.Promise.lazy(() =>
 			typedly.Promise.awaitLatest((value: number) => typedly.Promise.create<number>(resolve => resolve(value)))
 		)
@@ -109,19 +109,24 @@ describe("Promise", () => {
 	})
 	it("awaitLatest", async () => {
 		let result: number
+		console.log("1")
 		const processed = typedly.Promise.awaitLatest(work)
+		console.log("2", processed)
 		result = (await Promise.all([processed(2), processed(3), processed(5)])).reduce(
 			(result, number) => result + number,
 			0
 		)
+		console.log("3")
 		// older versions of calls to `processed()` will only resolved if it finishes before another call to `processed()` starts.
 		// if more calls occurs before it finishes it will await result from the latest call.
 		// expecting 3 * value of last call
 		expect(result).toEqual(15)
+		console.log("4")
 		result = (await Promise.all([processed(5), processed(3), processed(2)])).reduce(
 			(result, number) => result + number,
 			0
 		)
+		console.log("5")
 		expect(result).toEqual(6)
 	})
 	it("awaitLatest + lazy", async () => {

--- a/Promise.spec.ts
+++ b/Promise.spec.ts
@@ -9,6 +9,12 @@ describe("Promise", () => {
 		const values: typedly.Promise.Maybe<number>[] = [new Promise(r => r(1)), 1]
 		return expect((await Promise.all(values)).every(value => value == 1)).toEqual(true)
 	})
+	it(`typedly.Promise.from`, async () => {
+		const promise = new Promise<boolean>(resolve => setTimeout(() => resolve(false), Number.MAX_SAFE_INTEGER))
+		const typedlyPromise = typedly.Promise.from(promise)
+		typedlyPromise.resolve(true)
+		expect(await typedlyPromise).toEqual(true)
+	})
 	it(`typedly.Promise "normal" resolve`, async () => {
 		const promise = typedly.Promise.create(resolve => setTimeout(() => resolve(1), 0))
 		expect(await promise).toEqual(1)

--- a/Promise.ts
+++ b/Promise.ts
@@ -1,15 +1,29 @@
-export type Promise<T> = globalThis.Promise<T>
+export type Promise<T, R = any> = globalThis.Promise<T> & { resolve: Promise.Resolve<T>; reject: Promise.Reject<R> }
 export namespace Promise {
-	export type Maybe<T> = T | Promise<T>
-	export type Lazy<T extends (...argument: any[]) => Promise<unknown>> = T & { force: T }
-	export function lazy<T extends (...argument: any[]) => Promise<unknown>>(
+	export type Resolve<T> = (value: T | globalThis.PromiseLike<T>) => void
+	export type Reject<T = any> = (reason: T) => void
+	export type Maybe<T> = T | globalThis.Promise<T> | Promise<T>
+	export type Lazy<T extends (...argument: any[]) => globalThis.Promise<unknown>> = T & { force: T }
+	export function create<T, R = any>(executor?: (resolve: Resolve<T>, reject: Reject<R>) => void): Promise<T> {
+		const callbacks: { resolve?: Resolve<T>; reject?: Reject } = {}
+		const promise = new globalThis.Promise<T>((resolve, reject) => {
+			callbacks.resolve = resolve
+			callbacks.reject = reject
+			executor?.(resolve, reject)
+		})
+		return Object.assign(promise, {
+			resolve: (...parameters: Parameters<Resolve<T>>) => callbacks.resolve?.(...parameters),
+			reject: (...parameters: Parameters<Reject>) => callbacks.reject?.(...parameters),
+		})
+	}
+	export function lazy<T extends (...argument: any[]) => globalThis.Promise<unknown>>(
 		factory: () => T,
 		duplicate?: (...argument: Parameters<T>) => unknown
 	): Lazy<T> {
 		const tasks = new Map<unknown, T>()
-		const ongoing = new Map<unknown, Promise<unknown>>()
+		const ongoing = new Map<unknown, globalThis.Promise<unknown>>()
 		const result = <T>((...argument: Parameters<T>) => {
-			let result: Promise<unknown>
+			let result: globalThis.Promise<unknown>
 			const key = duplicate?.(...argument)
 			let task = tasks.get(key)
 			if (!task)
@@ -31,12 +45,12 @@ export namespace Promise {
 			}),
 		})
 	}
-	export function awaitLatest<T extends (...argument: any[]) => Promise<unknown>>(task: T): T {
-		let latest: Promise<unknown>
+	export function awaitLatest<T extends (...argument: any[]) => globalThis.Promise<unknown>>(task: T): T {
+		let latest: globalThis.Promise<unknown>
 		return <T>(async (...argument) => {
 			latest = task(...argument)
 			return latest.then(async () => {
-				let result: Promise<unknown>
+				let result: globalThis.Promise<unknown>
 				do {
 					await (result = latest)
 				} while (result != latest)

--- a/Promise.ts
+++ b/Promise.ts
@@ -45,17 +45,33 @@ export namespace Promise {
 			}),
 		})
 	}
+	export function wait<T extends globalThis.Promise<T>>(promise: T, getLatest: () => T): T {
+		console.log("have resolve:", "resolve" in promise)
+		// convert to typedly Promise?
+		return promise.then(() => {
+			const latest = getLatest()
+			if (promise === latest)
+				return promise
+			return wait(latest, getLatest)
+		})
+	}
 	export function awaitLatest<T extends (...argument: any[]) => globalThis.Promise<unknown>>(task: T): T {
 		let latest: globalThis.Promise<unknown>
-		return <T>(async (...argument) => {
+		return <T>((...argument) => {
 			latest = task(...argument)
-			return latest.then(async () => {
-				let result: globalThis.Promise<unknown>
-				do {
-					await (result = latest)
-				} while (result != latest)
-				return result
-			})
+			const result = wait(latest, () => latest)
+			console.log("have result in result", "resolve" in result)
+			return result
 		})
+		// return <T>(async (...argument) => {
+		// 	latest = task(...argument)
+		// 	return latest.then(async () => {
+		// 		let result: globalThis.Promise<unknown>
+		// 		do {
+		// 			await (result = latest)
+		// 		} while (result != latest)
+		// 		return result
+		// 	})
+		// })
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4656,9 +4656,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.7",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+			"version": "3.3.8",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+			"integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
 			"dev": true,
 			"funding": [
 				{
@@ -4666,6 +4666,7 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},


### PR DESCRIPTION
* expanded the `typedly.Promise` type to have two new properties:
   * `resolve`: the intent is that this property should point to the internal promise resolve function. Usage is shown [here](https://github.com/utily/typedly/pull/13/files#diff-53a255db6fff8a61384577fbf0326b27e9f0a51a39100ddbce98aa3ce677e903R37) and [here](https://github.com/utily/typedly/pull/13/files#diff-53a255db6fff8a61384577fbf0326b27e9f0a51a39100ddbce98aa3ce677e903R15).
   * `reject`: the intent is that this property should point to the internal promise reject function. Usage is shown [here](https://github.com/utily/typedly/pull/13/files#diff-53a255db6fff8a61384577fbf0326b27e9f0a51a39100ddbce98aa3ce677e903R53).
* added `typedly.Promise.create(...)` function to create `typedly.Promise`s where the resolve and reject functions are exposed
* added a `typedly.Promise.from(...)` to create `typedly.Promise`s from internal javascript promises
* added fixes to `typedly.Promise.awaitLatest(...)` to always return a `typedly.Promise` with the help of `typedly.Promise.from(...)`