### PR TITLE
resolve and reject equal to internal resolve and reject

### DIFF
--- a/Promise.spec.ts
+++ b/Promise.spec.ts
@@ -15,6 +15,14 @@ describe("Promise", () => {
 		typedlyPromise.resolve(true)
 		expect(await typedlyPromise).toEqual(true)
 	})
+	it("resolve equality", async () => {
+		const promise = typedly.Promise.create<number>(async resolve => {
+			await typedly.Promise.create(resolve => setTimeout(resolve, 0))
+			expect(promise.resolve).toEqual(resolve)
+			resolve(1)
+		})
+		expect(await promise).toEqual(1)
+	})
 	it(`typedly.Promise "normal" resolve`, async () => {
 		const promise = typedly.Promise.create(resolve => setTimeout(() => resolve(1), 0))
 		expect(await promise).toEqual(1)

--- a/Promise.ts
+++ b/Promise.ts
@@ -5,16 +5,13 @@ export namespace Promise {
 	export type Maybe<T> = T | globalThis.Promise<T> | Promise<T>
 	export type Lazy<T extends (...argument: any[]) => globalThis.Promise<unknown>> = T & { force: T }
 	export function create<T, R = any>(executor?: (resolve: Resolve<T>, reject: Reject<R>) => void): Promise<T> {
-		const callbacks: { resolve?: Resolve<T>; reject?: Reject } = {}
+		const functions: { resolve: Resolve<T>; reject: Reject } = { resolve: () => {}, reject: () => {} }
 		const promise = new globalThis.Promise<T>((resolve, reject) => {
-			callbacks.resolve = resolve
-			callbacks.reject = reject
+			functions.resolve = resolve
+			functions.reject = reject
 			executor?.(resolve, reject)
 		})
-		return Object.assign(promise, {
-			resolve: (...parameters: Parameters<Resolve<T>>) => callbacks.resolve?.(...parameters),
-			reject: (...parameters: Parameters<Reject>) => callbacks.reject?.(...parameters),
-		})
+		return Object.assign(promise, functions)
 	}
 	export function from<T>(promise: PromiseLike<T>): Promise<T, unknown> {
 		return Promise.create(async (resolve, reject) => {


### PR DESCRIPTION
The resolve and reject property is now the same as the given resolve and reject functions from the JS promise constructor.
[The added test](https://github.com/utily/typedly/pull/14/files#diff-53a255db6fff8a61384577fbf0326b27e9f0a51a39100ddbce98aa3ce677e903R21) fails without these changes.